### PR TITLE
Update predict.py

### DIFF
--- a/back-end/core/predict.py
+++ b/back-end/core/predict.py
@@ -8,5 +8,6 @@ def predict(dataset, model, ext):
     print(file_name)
     x = cv2.imread(x)
     img_y, image_info = model.detect(x)
-    cv2.imwrite('./tmp/draw/{}.{}'.format(file_name, ext), img_y)
+    if cv2.imwrite('./tmp/draw/{}.{}'.format(file_name, ext), img_y):
+        raise Exception('保存图片时出错.Error saving thepicture.')
     return image_info


### PR DESCRIPTION
Add exception handling: When OpenCV is unable to save picture to disk, raise an exception.
添加异常处理：当OpenCV无法将图片保存到磁盘时，抛出异常。
---------------------
OpenCV如果不能保存图片的时候是不会报错的，只会返回一个boolean。之前改你的开源代码的时候保存检测下来的图片路径写错了，一直保存不了图片，但是控制台也不报错。😵查了好久才发现OpenCV的imwrite就是不报错，只返回true or false...
谢谢你的开源！👍👍